### PR TITLE
Child forms

### DIFF
--- a/_components/crud.vue
+++ b/_components/crud.vue
@@ -361,14 +361,15 @@ export default {
     update(item) {
       //Validate if can update
       if (this.hasPermission.edit) {
+        let params = this.paramsProps
         //Set custom item crud fields
         if (item.crudFields) this.itemCrudFields = this.$clone(item.crudFields)
         //Set data to update
         if (item.id.field) this.fieldData = item.id.field
         //Go to edit
-        if (this.params.update.to) this.$router.push({name: this.params.update.to, params: item})
+        if (params.update.to) this.$router.push({name: params.update.to, params: item})
         //Edit by method
-        else if (this.params.update.method) this.params.update.method(item)
+        else if (params.update.method) params.update.method(item)
         else {
           this.itemIdToEdit = item.id
           this.showModal = true

--- a/_components/form.vue
+++ b/_components/form.vue
@@ -7,33 +7,42 @@
       <div id="cardContent" :class="`row ${existFormRight ? 'col-2' : 'col-1'}`">
         <div class="relative-position col-12">
           <!--Forms-->
-          <p
-            v-if="showInformationAboutTheForm"
-            class="q-mb-lg"
-          >
-            {{ showInformationAboutTheForm }}
-          </p>
+          <dynamic-field
+            v-if="fieldBanner"
+            :field="fieldBanner"
+          />
           <q-form 
             autocorrect="off" 
             autocomplete="off" 
             ref="formContent" 
             class="row q-col-gutter-md col-12"
-            @submit="(!isUpdate && !field) ?  createItem() : updateItem()" v-if="success"
+            @submit="(!isUpdate && !field) ?  createItem() : updateItem()" 
+            v-if="success"
             @validation-error="$alert.error($tr('isite.cms.message.formInvalid'))"
           >
             <!--Language-->
-            <div :class="locale.languages && (locale.languages.length >= 2) ? 'col-12' : 'q-pa-none'"
-                 v-show="locale.fieldsTranslatable && Object.keys(locale.fieldsTranslatable).length">
-              <locales v-model="locale" ref="localeComponent" :form="$refs.formContent"/>
+            <div 
+              :class="locale.languages && (locale.languages.length >= 2) ? 'col-12' : 'q-pa-none'"
+              v-show="locale.fieldsTranslatable && Object.keys(locale.fieldsTranslatable).length"
+            >
+              <locales 
+                v-model="locale" 
+                ref="localeComponent" 
+                :form="$refs.formContent"
+              />
             </div>
 
             <!--Form-->
-            <div v-for="(pos,key) in ['formLeft','formRight']" :key="pos"
-                 v-if="locale.success && paramsProps[pos] && Object.keys(paramsProps[pos]).length"
-                 :class="`col-12 ${existFormRight ? ((pos=='formLeft') ? 'col-md-7' : 'col-md-5') : ''}`">
+            <div 
+              v-for="(pos,key) in ['formLeft','formRight']" :key="pos"
+              v-if="locale.success && paramsProps[pos] && Object.keys(paramsProps[pos]).length"
+              :class="`col-12 ${existFormRight ? ((pos=='formLeft') ? 'col-md-7' : 'col-md-5') : ''}`"
+            >
               <div>
                 <!--Fields-->
-                <div v-for="(field, key) in  customFieldProps[pos]" :key="key" :ref="key">
+                <div 
+                  v-for="(field, key) in customFieldProps[pos]" :key="key" :ref="key"
+                >
                   <!--Dynamic fake field-->
                   <dynamic-field 
                     v-model="locale.formTemplate[field.fakeFieldName || 'options'][field.name || key]"
@@ -154,8 +163,21 @@ export default {
       if (this.itemId === false) return false
       return true
     },
-    showInformationAboutTheForm() {
-      return  this.paramsProps?.update?.aboutTheForm
+    fieldBanner() {
+      const description = this.isUpdate 
+        ? this.paramsProps?.update?.description 
+        : this.paramsProps?.create?.description
+
+      if (!description) return null
+
+      return  {
+        type: 'banner',
+        props: {
+          color: 'blue-grey-4',
+          icon: 'fas fa-exclamation-triangle',
+          message: description
+        }
+      }
     },
     //Actions to store component
     componentStore() {
@@ -584,6 +606,3 @@ export default {
   }
 }
 </script>
-
-<style lang="stylus">
-</style>

--- a/_components/index.vue
+++ b/_components/index.vue
@@ -5,14 +5,15 @@
       <!--Page Actions-->
       <div class="q-my-md">
         <page-actions
-            :extra-actions="tableActions"
-            :excludeActions="params.read.noFilter ? ['filter'] : []"
-            :searchAction="params.read.searchAction"
-            :title="tableTitle" @search="val => search(val)"
-            @new="handlerActionCreate()"
-            @refresh="getDataTable(true)"
-            ref="pageActionRef"
-            :tour-name="tourName"
+          :extra-actions="tableActions"
+          :excludeActions="params.read.noFilter ? ['filter'] : []"
+          :searchAction="params.read.searchAction"
+          :title="tableTitle" 
+          @search="val => search(val)"
+          @new="handlerActionCreate()"
+          @refresh="getDataTable(true)"
+          ref="pageActionRef"
+          :tour-name="tourName"
         />
       </div>
       <!-- Bulk Actions -->
@@ -104,7 +105,6 @@
                       color="blue-grey"
                       :icon="tableCollapseIcon(props.key)"
                       @click="toggleRelationContent(props)"
-
                   />
                 </div>
                 <!--Actions column-->
@@ -245,7 +245,7 @@
                         <q-separator v-if="['id'].indexOf(col.name) != -1" class="q-mt-sm"/>
                       </q-item-label>
                       <!--Field value-->
-                      <q-item-label v-if="col.name != 'id'" class="ellipsis text-grey-6">
+                      <q-item-label v-if="col.name != 'id'" class="text-grey-6">
                         <!-- status columns -->
                         <div v-if="(['status','active'].includes(col.name)) || col.asStatus"
                              class="text-left">
@@ -287,10 +287,11 @@
                                     v-else
                                     @click="rowclick(col,props.row)"
                                     v-html="data.data"
-                                    :class="(isActionableColumn(col) ? 'cursor-pointer' : '') + (col.textColor ? ' text-'+col.textColor : '')"
+                                    :class="'ellipsis ' + (isActionableColumn(col) ? 'cursor-pointer' : '') + (col.textColor ? ' text-'+col.textColor : '')"
                                 >
                                   {{ data.data }}
                                 </div>
+                                <q-tooltip>{{ data.data }}</q-tooltip>
                               </div>
                             </template>
                           </promiseTemplate>
@@ -477,7 +478,6 @@ export default {
           action: () => {
             const alternativeShow = this.readShowAs != "table" ? this.readShowAs : 'grid'
             this.localShowAs = this.localShowAs === alternativeShow ? 'table' : alternativeShow;
-            this.getDataTable(true)
           },
         })
       }
@@ -746,6 +746,7 @@ export default {
     async rowclick(col, row) {
       // if is an actionable column
       if (this.isActionableColumn(col)) {
+        
         //if the col has an action callback
         if (col.action) {
           await col.action(row)
@@ -754,7 +755,6 @@ export default {
           let defaultAction = this.fieldActions(col).find(action => {
             return action.default ?? false
           })
-
           if (defaultAction.action) await defaultAction.action(row)
         }
       }
@@ -974,18 +974,7 @@ export default {
         return action.default ?? false;
       })
       //Add default actions
-      actions = [...actions,
-        //Export
-        {
-          label: this.$tr('isite.cms.label.export'),
-          vIf: this.exportParams,
-          icon: 'fa-light fa-download',
-          action: (item) => this.$refs.exportComponent.showReportItem({
-            item: item,
-            exportParams: {fileName: `${this.exportParams.fileName}-${item.id}`},
-            filter: {id: item.id}
-          })
-        },
+      actions = [
         {//Edit action
           icon: 'fa-light fa-pencil',
           color: 'green',
@@ -1012,7 +1001,19 @@ export default {
           action: (item) => {
             this.deleteItem(item)
           }
-        }
+        },
+         //Export
+         {
+          label: this.$tr('isite.cms.label.export'),
+          vIf: this.exportParams,
+          icon: 'fa-light fa-download',
+          action: (item) => this.$refs.exportComponent.showReportItem({
+            item: item,
+            exportParams: {fileName: `${this.exportParams.fileName}-${item.id}`},
+            filter: {id: item.id}
+          })
+        },
+        ...actions
       ]
 
       //Order field actions
@@ -1057,7 +1058,8 @@ export default {
             this.$crud.show(this.params.apiRoute, actionValue, requestParams).then(response => {
               actionCrudData.action(response.data)
             }).catch(error => {
-              this.$apiResponse.handleError(error, () => {})
+              this.$apiResponse.handleError(error, () => {
+              })
             })
           }
         } else {


### PR DESCRIPTION
Settings to implement the custom interface of child forms.

A banner has been added to the edit modal of the form fields, leveraging the one used in dynamic-field. While it was initially implemented for this specific modal, it can be utilized anywhere form.vue from qcrud/components is used. You just need to pass the 'description' attribute within the 'update' attribute. You can check qform/uses/useFields for an example.