### PR TITLE
- added tooltip option for crud actions:

### DIFF
--- a/_components/index.vue
+++ b/_components/index.vue
@@ -170,8 +170,8 @@
                           >
                             {{ data.data }}
                           </div>
-                          <q-tooltip>
-                            {{ data.data }}
+                          <q-tooltip v-if="col.tooltip == undefined || col.tooltip">
+                            {{ col.tooltip || data.data }}
                             <label v-if="isActionableColumn(col)" class="text-weight-bold">
                               <br> {{$tr('isite.cms.label.clickToAction')}}
                             </label>

--- a/_docs/Components/Qcrud.mdx
+++ b/_docs/Components/Qcrud.mdx
@@ -55,6 +55,7 @@ There is three components that build a CRUD component used on pages
               columns: [
                 {name: 'id', label: this.$tr('ui.form.id'), field: 'id', style: 'width: 50px'},
                 {name: 'name', label: this.$tr('ui.form.title'), field: 'title', align: 'rigth'},
+                {name: 'phone', label: this.$tr('ui.form.phone'), align: 'left', format: val => '<i class="fa-light fa-phone">', tooltip: this.$tr('ui.form.tooltip'), action: (item) => this.getPhoneNumber(item) }
                 //...
               ],
               requestParams: {include: 'parent'}


### PR DESCRIPTION
- example: actions: [ { name: 'viewCode', icon: 'fa-light fa-qrcode', color: 'info', tooltip: 'tooltip text example', action: (item) => (){} } ]